### PR TITLE
Improve JSON logging

### DIFF
--- a/filter/logging_cfg.py
+++ b/filter/logging_cfg.py
@@ -1,19 +1,45 @@
-import logging, os, sys
+import json
+import logging
+import os
+import sys
 from logging.config import dictConfig
+
+
+class JsonFormatter(logging.Formatter):
+    """Pretty JSON formatter for console logs."""
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        obj = {
+            "time": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.funcName:
+            obj["func"] = record.funcName
+        if record.exc_info:
+            obj["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(obj, indent=2)
+
+
 def setup_logging(level: str | int | None = None):
     level = level or os.getenv("FASTBACK_LOG", "WARNING")
-    dictConfig({
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "std": {"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"}
-        },
-        "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "formatter": "std",
-                "stream": sys.stdout,
-            }
-        },
-        "root": {"handlers": ["console"], "level": level},
-    })
+    dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "json": {
+                    "()": "filter.logging_cfg.JsonFormatter",
+                }
+            },
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "json",
+                    "stream": sys.stdout,
+                }
+            },
+            "root": {"handlers": ["console"], "level": level},
+        }
+    )

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,12 @@
 ```bash
 pip install fastbackfilter[perf]
 python -m fastbackfilter.cli one sample.pdf
+```
+
+## Logging
+
+Set `FASTBACK_LOG` to change verbosity. Logs are emitted as pretty JSON, for example:
+
+```bash
+FASTBACK_LOG=INFO python -m fastbackfilter.cli one sample.pdf
+```


### PR DESCRIPTION
## Summary
- format logs with a custom JSON formatter
- document JSON logging example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849952650a88331bea96dc864dfb562