### PR TITLE
Improve engine detection & add support for more formats

### DIFF
--- a/fastbackfilter/core.py
+++ b/fastbackfilter/core.py
@@ -39,10 +39,9 @@ def detect(
                 best = res
                 if res.candidates[0].confidence >= 0.99:
                     break
-    if best is None and cap_bytes is not None and isinstance(source, (str, Path)):
+    if (best is None or best.candidates[0].confidence == 0.0) and cap_bytes is not None and isinstance(source, (str, Path)):
         payload = Path(source).read_bytes()
         for name in engines:
-            
             res = get(name)()(payload)
             if res.candidates:
                 best = res

--- a/fastbackfilter/engines/fallback.py
+++ b/fastbackfilter/engines/fallback.py
@@ -6,7 +6,7 @@ from ..registry import register
 @register
 class OctetEngine(EngineBase):
     name = "fallbackengine"
-    cost = 0.0
+    cost = 100.0
 
     def sniff(self, payload: bytes) -> Result:
         return Result(

--- a/fastbackfilter/engines/image.py
+++ b/fastbackfilter/engines/image.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from ..types import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+@register
+class ImageEngine(EngineBase):
+    name = "image"
+    cost = 0.05
+
+    def sniff(self, payload: bytes) -> Result:
+        cand = []
+        if payload.startswith(b"\xff\xd8\xff"):
+            cand.append(Candidate(media_type="image/jpeg", extension="jpg", confidence=0.99))
+        elif payload.startswith(b"GIF87a") or payload.startswith(b"GIF89a"):
+            cand.append(Candidate(media_type="image/gif", extension="gif", confidence=0.99))
+        return Result(candidates=cand)

--- a/fastbackfilter/engines/text.py
+++ b/fastbackfilter/engines/text.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import string
+from ..types import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+@register
+class TextEngine(EngineBase):
+    name = "text"
+    cost = 0.05
+
+    def sniff(self, payload: bytes) -> Result:
+        sample = payload[:512]
+        try:
+            text = sample.decode("utf-8")
+        except UnicodeDecodeError:
+            return Result(candidates=[])
+        printable = set(string.printable)
+        printable_count = sum(1 for c in text if c in printable or c in "\n\r\t")
+        ratio = printable_count / max(len(text), 1)
+        if ratio > 0.95:
+            cand = Candidate(media_type="text/plain", extension="txt", confidence=0.95)
+            return Result(candidates=[cand])
+        return Result(candidates=[])

--- a/fastbackfilter/registry.py
+++ b/fastbackfilter/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from types import MappingProxyType
 from .exceptions import UnsupportedType
+
 _engines: dict[str, type] = {}
 def register(cls):
     _engines[cls.name] = cls
@@ -10,5 +11,12 @@ def get(name: str):
         return _engines[name]
     except KeyError as exc:
         raise UnsupportedType(name) from exc
-list_engines = lambda: sorted(_engines)
+def list_engines() -> list[str]:
+    """Return engine names ordered by ``cost`` attribute."""
+    return [
+        name
+        for name, cls in sorted(
+            _engines.items(), key=lambda kv: getattr(kv[1], "cost", 1.0)
+        )
+    ]
 all_engines = lambda: MappingProxyType(_engines)


### PR DESCRIPTION
## Summary
- order engines by `cost`
- move fallback engine to last position
- add new engines for plain text and images
- avoid fallback preventing full file scan

## Testing
- `pip install -e .`
- `pip install olefile`
- `python -m fastbackfilter.cli one sample.pdf`
- `python -m fastbackfilter.cli one sample.docx`
- `python -m fastbackfilter.cli one sample.xlsx`
- `python -m fastbackfilter.cli one sample.jpg`
- `python -m fastbackfilter.cli one sample.gif`


------
https://chatgpt.com/codex/tasks/task_e_684adb27070c8331898224112d9d322b