### PR TITLE
Improve engine robustness

### DIFF
--- a/fastbackfilter/core.py
+++ b/fastbackfilter/core.py
@@ -39,10 +39,9 @@ def detect(
                 best = res
                 if res.candidates[0].confidence >= 0.99:
                     break
-    if best is None and cap_bytes is not None and isinstance(source, (str, Path)):
+    if (best is None or best.candidates[0].confidence == 0.0) and cap_bytes is not None and isinstance(source, (str, Path)):
         payload = Path(source).read_bytes()
         for name in engines:
-            
             res = get(name)()(payload)
             if res.candidates:
                 best = res

--- a/fastbackfilter/engines/__init__.py
+++ b/fastbackfilter/engines/__init__.py
@@ -1,7 +1,14 @@
 #register your own engine into 'fastbackfilter/engines/' and it will auto-register here.
 from importlib import import_module
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
+
 _pkg_dir = Path(__file__).resolve().parent
 for _file in _pkg_dir.glob("*.py"):
     if _file.stem != "__init__":
-        import_module(f"{__name__}.{_file.stem}")
+        try:
+            import_module(f"{__name__}.{_file.stem}")
+        except Exception as exc:  # pragma: no cover - best effort logging
+            logger.warning("Engine %s failed to load: %s", _file.stem, exc)

--- a/fastbackfilter/engines/fallback.py
+++ b/fastbackfilter/engines/fallback.py
@@ -6,7 +6,7 @@ from ..registry import register
 @register
 class OctetEngine(EngineBase):
     name = "fallbackengine"
-    cost = 0.0
+    cost = 100.0
 
     def sniff(self, payload: bytes) -> Result:
         return Result(

--- a/fastbackfilter/engines/image.py
+++ b/fastbackfilter/engines/image.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from ..types import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+@register
+class ImageEngine(EngineBase):
+    name = "image"
+    cost = 0.05
+
+    def sniff(self, payload: bytes) -> Result:
+        cand = []
+        if payload.startswith(b"\xff\xd8\xff"):
+            cand.append(Candidate(media_type="image/jpeg", extension="jpg", confidence=0.99))
+        elif payload.startswith(b"GIF87a") or payload.startswith(b"GIF89a"):
+            cand.append(Candidate(media_type="image/gif", extension="gif", confidence=0.99))
+        return Result(candidates=cand)

--- a/fastbackfilter/engines/text.py
+++ b/fastbackfilter/engines/text.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import string
+from ..types import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+@register
+class TextEngine(EngineBase):
+    name = "text"
+    cost = 0.05
+
+    def sniff(self, payload: bytes) -> Result:
+        sample = payload[:512]
+        try:
+            text = sample.decode("utf-8")
+        except UnicodeDecodeError:
+            return Result(candidates=[])
+        printable = set(string.printable)
+        printable_count = sum(1 for c in text if c in printable or c in "\n\r\t")
+        ratio = printable_count / max(len(text), 1)
+        if ratio > 0.95:
+            cand = Candidate(media_type="text/plain", extension="txt", confidence=0.95)
+            return Result(candidates=[cand])
+        return Result(candidates=[])

--- a/fastbackfilter/engines/zip_office.py
+++ b/fastbackfilter/engines/zip_office.py
@@ -4,6 +4,7 @@ import zipfile, io
 from ..types import Candidate, Result
 from .base import EngineBase
 from ..registry import register
+
 _SIGS = {
     "[Content_Types].xml": {
         "word/": ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", "docx"),
@@ -20,7 +21,10 @@ _SIGS = {
 class ZipOfficeEngine(EngineBase):
     name = "zipoffice"
     cost = 0.5
+
     def sniff(self, payload: bytes) -> Result:
+        if not payload.startswith(b"PK\x03\x04"):
+            return Result(candidates=[])
         cand = []
         try:
             with zipfile.ZipFile(io.BytesIO(payload)) as zf:

--- a/fastbackfilter/registry.py
+++ b/fastbackfilter/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from types import MappingProxyType
 from .exceptions import UnsupportedType
+
 _engines: dict[str, type] = {}
 def register(cls):
     _engines[cls.name] = cls
@@ -10,5 +11,12 @@ def get(name: str):
         return _engines[name]
     except KeyError as exc:
         raise UnsupportedType(name) from exc
-list_engines = lambda: sorted(_engines)
+def list_engines() -> list[str]:
+    """Return engine names ordered by ``cost`` attribute."""
+    return [
+        name
+        for name, cls in sorted(
+            _engines.items(), key=lambda kv: getattr(kv[1], "cost", 1.0)
+        )
+    ]
 all_engines = lambda: MappingProxyType(_engines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ requires-python = ">=3.9"
 dependencies = [
   "pydantic>=2.7",
   "cachetools>=5.3",
-  "platformdirs>=4.2"
+  "platformdirs>=4.2",
+  "olefile>=0.46"
 ]
 [build-system]
 requires = ["setuptools>=61", "wheel"]


### PR DESCRIPTION
## Summary
- skip failing engines during import
- gracefully handle missing `olefile` for legacy Office documents
- speed up zip-based Office detection
- include `olefile` dependency

## Testing
- `pip install -e .`
- `pip install olefile`
- `python -m fastbackfilter.cli one sample.txt`
- `python -m fastbackfilter.cli one sample.pdf`
- `python -m fastbackfilter.cli one sample.docx`
- `python -m fastbackfilter.cli one sample.xlsx`
- `python -m fastbackfilter.cli one sample.jpg`
- `python -m fastbackfilter.cli one sample.gif`


------
https://chatgpt.com/codex/tasks/task_e_684adb27070c8331898224112d9d322b