### PR TITLE
Optimize engine dispatch

### DIFF
--- a/fastbackfilter/core.py
+++ b/fastbackfilter/core.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 from .cache import get as cache_get, put as cache_put
 from .exceptions import FastbackError
-from .registry import get, list_engines
+from .registry import get, list_engines, get_instance
 from .types import Result, Candidate
 logger = logging.getLogger(__name__)
 def _load_bytes(source: str | Path | bytes, cap: int | None) -> bytes:
@@ -29,11 +29,11 @@ def detect(
 ) -> Result:
     payload = _load_bytes(source, cap_bytes)
     if engine != "auto":
-        return get(engine)()(payload)
+        return get_instance(engine)(payload)
     engines: Sequence[str] = engine_order or list_engines()
     best: Result | None = None
     for name in engines:
-        res = get(name)()(payload)
+        res = get_instance(name)(payload)
         if res.candidates:
             if best is None or res.candidates[0].confidence > best.candidates[0].confidence:
                 best = res
@@ -42,7 +42,7 @@ def detect(
     if (best is None or best.candidates[0].confidence == 0.0) and cap_bytes is not None and isinstance(source, (str, Path)):
         payload = Path(source).read_bytes()
         for name in engines:
-            res = get(name)()(payload)
+            res = get_instance(name)(payload)
             if res.candidates:
                 best = res
                 break

--- a/fastbackfilter/registry.py
+++ b/fastbackfilter/registry.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 from types import MappingProxyType
 from .exceptions import UnsupportedType
 
+
 _engines: dict[str, type] = {}
+_engine_instances: dict[str, "EngineBase"] = {}
 def register(cls):
     _engines[cls.name] = cls
     return cls
@@ -11,6 +13,14 @@ def get(name: str):
         return _engines[name]
     except KeyError as exc:
         raise UnsupportedType(name) from exc
+
+def get_instance(name: str) -> "EngineBase":
+    """Return a cached instance of the requested engine."""
+    from .engines.base import EngineBase
+    cls = get(name)
+    if name not in _engine_instances:
+        _engine_instances[name] = cls()
+    return _engine_instances[name]
 def list_engines() -> list[str]:
     """Return engine names ordered by ``cost`` attribute."""
     return [


### PR DESCRIPTION
## Summary
- avoid repeatedly instantiating engines by caching instances
- update core detection to use cached engine instances

## Testing
- `python -m fastbackfilter.cli --help | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684aecb824088331a20874a63bc1ace5