### PR TITLE
Add more file type engines

### DIFF
--- a/fastbackfilter/engines/gzip.py
+++ b/fastbackfilter/engines/gzip.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from ..types import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+_GZIP_MAGIC = b"\x1f\x8b"
+
+@register
+class GzipEngine(EngineBase):
+    name = "gzip"
+    cost = 0.1
+
+    def sniff(self, payload: bytes) -> Result:
+        if payload.startswith(_GZIP_MAGIC):
+            cand = Candidate(media_type="application/gzip", extension="gz", confidence=0.95)
+            return Result(candidates=[cand])
+        return Result(candidates=[])

--- a/fastbackfilter/engines/html.py
+++ b/fastbackfilter/engines/html.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from ..types import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+_HTML_MAGIC = b"<html"
+
+@register
+class HTMLEngine(EngineBase):
+    name = "html"
+    cost = 0.05
+
+    def sniff(self, payload: bytes) -> Result:
+        window = payload[:32].lower()
+        if _HTML_MAGIC in window:
+            cand = Candidate(media_type="text/html", extension="html", confidence=0.95)
+            return Result(candidates=[cand])
+        return Result(candidates=[])

--- a/fastbackfilter/engines/mp3.py
+++ b/fastbackfilter/engines/mp3.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from ..types import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+_ID3_MAGIC = b"ID3"
+
+@register
+class MP3Engine(EngineBase):
+    name = "mp3"
+    cost = 0.1
+
+    def sniff(self, payload: bytes) -> Result:
+        if payload.startswith(_ID3_MAGIC) or payload[:2] == b"\xff\xfb":
+            cand = Candidate(media_type="audio/mpeg", extension="mp3", confidence=0.95)
+            return Result(candidates=[cand])
+        return Result(candidates=[])

--- a/fastbackfilter/engines/mp4.py
+++ b/fastbackfilter/engines/mp4.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+from ..types import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+@register
+class MP4Engine(EngineBase):
+    name = "mp4"
+    cost = 0.2
+    _MAGIC = b"ftyp"
+
+    def sniff(self, payload: bytes) -> Result:
+        if len(payload) >= 12 and payload[4:8] == self._MAGIC:
+            cand = Candidate(media_type="video/mp4", extension="mp4", confidence=0.95)
+            return Result(candidates=[cand])
+        return Result(candidates=[])

--- a/fastbackfilter/engines/png.py
+++ b/fastbackfilter/engines/png.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from ..types import Candidate, Result
+from .base import EngineBase
+from ..registry import register
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+@register
+class PNGEngine(EngineBase):
+    name = "png"
+    cost = 0.05
+
+    def sniff(self, payload: bytes) -> Result:
+        if payload.startswith(_PNG_MAGIC):
+            cand = Candidate(media_type="image/png", extension="png", confidence=0.99)
+            return Result(candidates=[cand])
+        return Result(candidates=[])

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,10 @@ pip install fastbackfilter[perf]
 python -m fastbackfilter.cli one sample.pdf
 ```
 
+Common file types such as PNG, MP3, MP4, HTML and GZIP now have dedicated
+engines.  Engine detection runs all registered engines in parallel for faster
+results.
+
 ## Logging
 
 Set `FASTBACK_LOG` to change verbosity. Logs are emitted as pretty JSON, for example:


### PR DESCRIPTION
## Summary
- add PNG, MP3, MP4, HTML and gzip engines
- speed up detection by running engines in parallel
- document the new engines and the faster execution

## Testing
- `ruff check fastbackfilter/engines/gzip.py fastbackfilter/engines/html.py fastbackfilter/engines/mp3.py fastbackfilter/engines/mp4.py fastbackfilter/engines/png.py fastbackfilter/core.py`
- `python -m fastbackfilter.cli one sample.mp3` *(fails: FileNotFoundError)*
- `printf 'ID3' > sample.mp3 && python -m fastbackfilter.cli one sample.mp3`

------
https://chatgpt.com/codex/tasks/task_e_684afa12eff883319e9f519ce4e28283