### PR TITLE
Add detection report schema and CLI mapping

### DIFF
--- a/fastbackfilter/cli.py
+++ b/fastbackfilter/cli.py
@@ -3,14 +3,32 @@ import json
 import sys
 import argparse
 from pathlib import Path
+from datetime import datetime
 from .core import detect, scan_dir
+from .types import DetectionResult, Candidate, Result
+
+
+def to_detection_result(path: Path, res: Result) -> DetectionResult:
+    cand = res.candidates[0] if res.candidates else Candidate(media_type="", confidence=0.0)
+    size = path.stat().st_size if path.exists() else res.bytes_analyzed
+    return DetectionResult(
+        file_name=str(path),
+        detected_type=cand.media_type,
+        confidence_score=round(cand.confidence * 100, 2),
+        detection_method=res.engine,
+        timestamp=datetime.utcnow().isoformat() + "Z",
+        errors=[res.error] if res.error else [],
+        warnings=[],
+        analysis_time=res.elapsed_ms,
+        file_size=size,
+        mime_type=cand.media_type,
+        extension=cand.extension,
+        hash=res.hash,
+    )
 def cmd_one(args: argparse.Namespace) -> None:
-
     res = detect(args.file, cap_bytes=None, only=args.only, extensions=args.ext)
-
-    res = detect(args.file, cap_bytes=None, only=args.only)
-
-    json.dump(res.model_dump(), sys.stdout, indent=None if args.raw else 2)
+    report = to_detection_result(args.file, res)
+    json.dump(report.model_dump(), sys.stdout, indent=None if args.raw else 2)
     sys.stdout.write("\n")
 def cmd_all(args: argparse.Namespace) -> None:
     results = []
@@ -20,13 +38,10 @@ def cmd_all(args: argparse.Namespace) -> None:
         workers=args.workers,
         cap_bytes=None,
         only=args.only,
-
         extensions=args.ext,
-
-
     ):
-        line = {"path": str(path), **res.model_dump()}
-        results.append(line)
+        report = to_detection_result(path, res)
+        results.append(report.model_dump())
     json.dump(results, sys.stdout, indent=None if args.raw else 2)
     sys.stdout.write("\n")
 def build_parser() -> argparse.ArgumentParser:

--- a/fastbackfilter/detection_schema.json
+++ b/fastbackfilter/detection_schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DetectionResult",
+  "type": "object",
+  "required": [
+    "file_name",
+    "detected_type",
+    "confidence_score",
+    "detection_method",
+    "timestamp"
+  ],
+  "properties": {
+    "file_name": { "type": "string" },
+    "detected_type": { "type": "string" },
+    "confidence_score": { "type": "number", "minimum": 0, "maximum": 100 },
+    "detection_method": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "errors": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "analysis_time": { "type": "number" },
+    "file_size": { "type": "integer" },
+    "mime_type": { "type": "string" },
+    "extension": { "type": "string" },
+    "hash": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/fastbackfilter/types.py
+++ b/fastbackfilter/types.py
@@ -20,4 +20,19 @@ class Result(BaseModel):
     error: str | None = None
     hash: str | None = None
 
+
+class DetectionResult(BaseModel):
+    file_name: str
+    detected_type: str
+    confidence_score: float = Field(ge=0, le=100)
+    detection_method: str
+    timestamp: str
+    errors: List[str] = []
+    warnings: List[str] = []
+    analysis_time: float | None = None
+    file_size: int | None = None
+    mime_type: str | None = None
+    extension: str | None = None
+    hash: str | None = None
+
 BaseModel.model_config = ConfigDict(extra="forbid", populate_by_name=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ package-dir = {"" = "."}
 [tool.setuptools.packages.find]
 where    = ["."]
 include  = ["fastbackfilter", "fastbackfilter.*"]
+
+[tool.setuptools.package-data]
+fastbackfilter = ["detection_schema.json"]

--- a/readme.md
+++ b/readme.md
@@ -31,3 +31,5 @@ Set `FASTBACK_LOG` to change verbosity. Logs are emitted as pretty JSON, for exa
 *************************************************************
 FASTBACK_LOG=INFO python -m fastbackfilter.cli one sample.pdf
 *************************************************************
+
+A JSON schema describing the detection result format, including a file hash field, is provided in `fastbackfilter/detection_schema.json`.


### PR DESCRIPTION
## Summary
- include `hash` field in detection schema
- output CLI results using new DetectionResult format
- document schema update in the README

## Testing
- `python -m fastbackfilter.cli one fakeXML.xml --raw`
- `python -m fastbackfilter.cli all . --pattern fakeXML.xml --raw`


------
https://chatgpt.com/codex/tasks/task_e_68504677a04c8331bdc4856de2dd28ff